### PR TITLE
Fix links and typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you are new to the open source process, philosophy, and tools, we highly reco
 
 These projects are not officially hosted at The Linux Foundation, but some do have active communities or more recent offshoots or pivots. They might also serve as starting points for new projects.
 
-- [OpenHarvest](https://github.com/Call-for-Code/OpenHarvest) - OpenHarvest is a web application designed to balance farming production in India..
+- [OpenHarvest](https://github.com/Call-for-Code/OpenHarvest) - OpenHarvest is a web application designed to balance farming production in India.
 
 - [Project OWL](https://github.com/Project-Owl) projects that are not part of the ClusterDuck Protocol core Linux Foundation project.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These projects are not officially hosted at The Linux Foundation, but some do ha
 
 - [Sparrow Platform](https://github.com/sparrow-platform) - An Intelligent ubiquitous communication platform for medical and psychological well-being of disaster victims. [Website](https://sparrow-platform.com/). CFC 2019 finalist.
 
-- [Project AsTeR](http://www.project-aster.com/). AI-Powered Real-Time Emergency Calls Analysis and Effective Units Dispatching. The project has created an updated prototype called [Data911](https://911.calaster.com/). CFC 2019 finalist.
+- [Project AsTeR](https://github.com/cal-aster/data-911). AI-Powered Real-Time Emergency Calls Analysis and Effective Units Dispatching. The project has created an updated prototype called Data911. CFC 2019 finalist.
 
 - [Project Lantern](https://github.com/lantern-works), Long-Range Wireless Apps. CFC IBMer Challenge 2018 finalist.
 


### PR DESCRIPTION
There were two broken links, which were pointing at Project AsTeR's website, which is now down. So, it had to be replaced with an alive link, which I found by searching on GitHub: https://github.com/cal-aster/data-911

Plus, there was a simple typo: "india.." → "india."